### PR TITLE
Updated container name in Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ docker-compose up
 2. Done! Just use:
 
 ```
-docker exec -it postgres psql -U postgres
+docker exec -it pagila psql -U postgres
 ```
 
 ```


### PR DESCRIPTION
The current docker-compose file has a `container_name: pagila`. Therefore, update the instruction to use call and execute to pagila container name.