### PR TITLE
Add POSTGRES_DB: pagila to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       POSTGRES_PASSWORD: 123456
       POSTGRES_USER: postgres
+      POSTGRES_DB: pagila
     volumes:
       - ./pagila-schema.sql:/docker-entrypoint-initdb.d/1-pagila-schema.sql
       - ./pagila-schema-jsonb.sql:/docker-entrypoint-initdb.d/1-pagila-schema-jsonb.sql


### PR DESCRIPTION
### Summary
By default, the official PostgreSQL Docker image creates a database named `postgres` when no `POSTGRES_DB` is specified. This change ensures that a `pagila` database is created automatically, aligning the Docker-Compose setup with the documentation.

### Changes
- **`docker-compose.yml`**  
  - Added `POSTGRES_DB: pagila` under the `pagila` service’s `environment` section.

### Motivation
The README instructs users to run:
```bash
docker-compose up
docker exec -it pagila psql -U postgres
postgres=# \c pagila